### PR TITLE
Custom match for `myproject.venv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 </br>
 
 ## Why forked?
+
+Due to my personal use, I'd like to name venv based on root folder(e.g `myproject/myproject.venv`) which missing in the extension
+
 This project was forked from [autovenv by timothybrown](https://github.com/timothybrown/fish-autovenv), which has not been updated for more than three years.
 
 The project was forked because I wanted to add a few features and improve the plugin:

--- a/conf.d/autoenv.fish
+++ b/conf.d/autoenv.fish
@@ -20,7 +20,15 @@ function applyAutoenv
   # contains a `bin/activate.fish` file. If a venv is found we go ahead and break out of the loop,
   # otherwise continue. We go through all of this instead of just checking the CWD to handle cases
   # where the user moves into a sub-directory of the venv.
-  set _tree (pwd)
+
+  set _venv_count (count *.venv)
+
+  if test $_venv_count = "1"
+    set _tree (pwd)/*.venv
+  else
+    set _tree (pwd)
+  end
+  
   while test $_tree != "/"
     set -l _activate (string join '/' "$_tree" "$autovenv_dir" "bin/activate.fish")
     set -l _activate (string replace -a "//" "/" "$_activate")


### PR DESCRIPTION
I have convention for venv: `{myproject}.venv`, hacky patch to make this work